### PR TITLE
fix #13 Javascript uri correct ssl mode

### DIFF
--- a/formwidgets/AddressFinder.php
+++ b/formwidgets/AddressFinder.php
@@ -80,7 +80,7 @@ class AddressFinder extends FormWidgetBase
      */
     public function loadAssets()
     {
-        $this->addJs('http://maps.googleapis.com/maps/api/js?libraries=places&sensor=false');
+        $this->addJs('//maps.googleapis.com/maps/api/js?libraries=places&sensor=false');
         $this->addJs('js/location-autocomplete.js', 'core');
     }
 }


### PR DESCRIPTION
Some browsers do not load a resource on a none-ssl mode uri correctly, when the requesting webpage is in ssl mode,
